### PR TITLE
feat: split dryrun into read-only validation and export-only modes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,7 @@ jobs:
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
           CONFLUENCE_DRYRUN: "true"
+          CONFLUENCE_DEBUG: "true"
         run: |
           echo "Validating documentation in strict mode (dryrun - read-only)..."
           echo "This will connect to Confluence to validate pages but won't modify anything"
@@ -56,6 +57,7 @@ jobs:
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
           CONFLUENCE_DRYRUN: "false"
+          CONFLUENCE_DEBUG: "false"
         run: |
           echo "Building documentation and publishing to Confluence..."
           rm -rf site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,18 @@ jobs:
           echo "This will connect to Confluence to validate pages but won't modify anything"
           make docs-build-strict || echo "✓ Strict validation completed (warnings are expected)"
 
+      - name: Diff documentation (mode with dryrun)
+        env:
+          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+          CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
+          CONFLUENCE_DRYRUN: "true"
+          CONFLUENCE_DEBUG: "true"
+          CONFLUENCE_DIFF: "true"
+        run: |
+          echo "Validating documentation in strict mode (dryrun - read-only)..."
+          echo "This will connect to Confluence to validate pages but won't modify anything"
+          make docs-build || echo "✓ Diff validation completed (warnings are expected)"
+
       - name: Build and publish to Confluence
         env:
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,8 @@ jobs:
           CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
           CONFLUENCE_DRYRUN: "true"
         run: |
-          echo "Validating documentation in strict mode with dryrun..."
+          echo "Validating documentation in strict mode (dryrun - read-only)..."
+          echo "This will connect to Confluence to validate pages but won't modify anything"
           make docs-build-strict || echo "✓ Strict validation completed (warnings are expected)"
 
       - name: Build and publish to Confluence

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ lint-fix: py-ruff-fix ## Alias for py-ruff-fix
 py-mypy: ## Run mypy type checker
 py-mypy: cmd-exists-uv
 	@echo "$(BLUE)Running mypy type checker...$(RESET)"
-	uv --native-tls run mypy mkdocs_with_confluence tests
+	MYPYPATH=src uv --native-tls run mypy src/mkdocs_to_confluence
 	@echo "$(GREEN)✓ Type checking complete$(RESET)"
 
 py-security: ## Run security audit
@@ -92,20 +92,20 @@ py-security: cmd-exists-uv
 	-uv --native-tls run pip-audit
 	@echo ""
 	@echo "$(YELLOW)Scanning code with bandit...$(RESET)"
-	uv --native-tls run bandit -r mkdocs_with_confluence
+	uv --native-tls run bandit -r src/mkdocs_to_confluence
 	@echo "$(GREEN)✓ Security audit complete$(RESET)"
 
 py-complexity: ## Run complexity analysis
 py-complexity: cmd-exists-uv
 	@echo "$(BLUE)Running complexity analysis...$(RESET)"
 	@echo "$(YELLOW)Cyclomatic Complexity:$(RESET)"
-	@uv --native-tls run radon cc --min B --max F --show-complexity --average mkdocs_with_confluence
+	@uv --native-tls run radon cc --min B --max F --show-complexity --average src/mkdocs_to_confluence
 	@echo ""
 	@echo "$(YELLOW)Maintainability Index:$(RESET)"
-	@uv --native-tls run radon mi --min B --max F --show mkdocs_with_confluence
+	@uv --native-tls run radon mi --min B --max F --show src/mkdocs_to_confluence
 	@echo ""
 	@echo "$(YELLOW)Raw Metrics:$(RESET)"
-	@uv --native-tls run radon raw --summary mkdocs_with_confluence
+	@uv --native-tls run radon raw --summary src/mkdocs_to_confluence
 	@echo "$(GREEN)✓ Complexity analysis complete$(RESET)"
 
 complexity: py-complexity ## Alias for py-complexity
@@ -224,7 +224,7 @@ adr-list:
 ##@ Utilities
 run: ## Run the simple main.py application
 run: cmd-exists-uv
-	uv --native-tls run python -m mkdocs_with_confluence.main
+	uv --native-tls run python -m mkdocs_to_confluence.main
 
 run-cli: ## Run the Cyclopts CLI with --help
 run-cli: cmd-exists-uv

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ A MkDocs plugin that automatically publishes your documentation to Atlassian Con
 - **Environment Variable Support** - Secure credential management for CI/CD pipelines
 
 ### Developer Experience
-- **Dry Run Mode** - Export to filesystem for review before publishing to Confluence
+- **Dry Run Mode** - Validate against Confluence without making changes (read-only validation)
+- **Export-Only Mode** - Export to filesystem without connecting to Confluence
 - **Conditional Publishing** - Enable/disable based on environment variables
 - **Enhanced Markdown** - Extended syntax support including strikethrough, admonitions, task lists, and more
 - **Comprehensive Logging** - Verbose and debug modes with detailed content comparison

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -56,16 +56,16 @@ Or find it in Confluence:
 2. Click "Space Settings" (gear icon)
 3. Look for "Space Key" in the overview
 
-## Step 4: Test with Dry Run
+## Step 4: Test Locally (Export-Only)
 
-Before publishing to Confluence, test locally:
+Before publishing to Confluence, test locally with export-only mode:
 
 ```yaml
 plugins:
   - mkdocs-to-confluence:
       host_url: https://your-domain.atlassian.net/wiki/rest/api/content
       space: DOCS
-      dryrun: true
+      export_only: true  # Export to filesystem without connecting to Confluence
       export_dir: confluence-export
 ```
 
@@ -77,9 +77,12 @@ mkdocs build
 
 Check the `confluence-export/` directory to preview the converted pages.
 
+!!! tip "Validate Against Confluence"
+    Once you have credentials set up, use `dryrun: true` instead to validate against Confluence without making changes. See [Dry Run Mode](../user-guide/dry-run.md) for details.
+
 ## Step 5: Publish to Confluence
 
-Remove or set `dryrun: false` to publish:
+Remove `export_only` or set it to `false` to publish:
 
 ```yaml
 plugins:
@@ -87,7 +90,7 @@ plugins:
       host_url: https://your-domain.atlassian.net/wiki/rest/api/content
       space: DOCS
       parent_page_name: Documentation
-      dryrun: false  # Or remove this line
+      export_only: false  # Or remove this line
 ```
 
 Build again:

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,8 @@ Automatically publish your MkDocs documentation to Atlassian Confluence during b
 - **Environment Variable Support** - Secure credential management for CI/CD pipelines
 
 ### Developer Experience
-- **Dry Run Mode** - Export to filesystem for review before publishing to Confluence
+- **Dry Run Mode** - Validate against Confluence without making changes (read-only validation)
+- **Export-Only Mode** - Export to filesystem without connecting to Confluence
 - **Conditional Publishing** - Enable/disable based on environment variables
 - **Enhanced Markdown** - Extended syntax support including strikethrough, admonitions, task lists, and more
 - **Comprehensive Logging** - Verbose and debug modes with detailed content comparison

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -166,18 +166,62 @@ Use cases:
 
 #### `dryrun`
 
-Enable dry-run mode to export pages to filesystem instead of uploading to Confluence.
+Enable dry-run mode for read-only validation against Confluence.
 
 **Default:** `false`
 
 ```yaml
 dryrun: true
+```
+
+When enabled:
+- **Connects to Confluence** in read-only mode (requires credentials)
+- Validates all pages against existing Confluence content
+- Performs content comparisons to detect changes
+- Detects orphaned pages
+- Shows what would be modified with "*WOULD UPDATE*", "*WOULD CREATE*" messages
+- Does NOT create, update, or delete anything
+
+!!! info "Changed in 0.7.0"
+    Previously, `dryrun` exported to filesystem only. Now it connects to Confluence for validation.
+    Use `export_only: true` for the old behavior (filesystem export without Confluence connection).
+
+Use cases:
+- Validate documentation before publishing
+- Preview what changes would be made
+- Check for orphaned pages without modifying anything
+- CI/CD validation workflows
+
+#### `export_only`
+
+Enable export-only mode to save pages to filesystem without connecting to Confluence.
+
+**Default:** `false`
+
+```yaml
+export_only: true
 export_dir: confluence-export
 ```
 
+When enabled:
+- **No Confluence connection** required
+- Exports all pages to filesystem in Confluence storage format
+- No validation, comparisons, or orphaned page detection
+- Faster than `dryrun` mode (no API calls)
+
+Use cases:
+- Generate Confluence-compatible HTML for manual upload
+- Archive documentation in Confluence format
+- Offline development without Confluence credentials
+- Preview Confluence rendering locally
+
+!!! tip "Dryrun vs Export-Only"
+    - Use `dryrun: true` when you want to **validate** against Confluence without making changes
+    - Use `export_only: true` when you want to **export** to filesystem without connecting to Confluence
+
 #### `export_dir`
 
-Directory for dry-run exports.
+Directory for filesystem exports (used by `export_only` mode).
 
 **Default:** `confluence-export`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -136,11 +136,13 @@ cleanup_orphaned_pages: true
     Orphaned pages are **permanently deleted**. Always test with `dryrun: true` first or review the warning messages before enabling cleanup.
 
 When `false` (default):
+
 - Warnings are logged about orphaned pages
 - No pages are deleted
 - You can manually review and delete orphaned pages
 
 When `true`:
+
 - Orphaned pages are automatically deleted
 - Logs show which pages were removed
 - Pages in `keep_pages` are preserved
@@ -160,6 +162,7 @@ keep_pages:
 ```
 
 Use cases:
+
 - Preserve manually-created pages
 - Keep archived documentation
 - Protect special pages from auto-deletion
@@ -175,6 +178,7 @@ dryrun: true
 ```
 
 When enabled:
+
 - **Connects to Confluence** in read-only mode (requires credentials)
 - Validates all pages against existing Confluence content
 - Performs content comparisons to detect changes
@@ -187,6 +191,7 @@ When enabled:
     Use `export_only: true` for the old behavior (filesystem export without Confluence connection).
 
 Use cases:
+
 - Validate documentation before publishing
 - Preview what changes would be made
 - Check for orphaned pages without modifying anything
@@ -204,18 +209,21 @@ export_dir: confluence-export
 ```
 
 When enabled:
+
 - **No Confluence connection** required
 - Exports all pages to filesystem in Confluence storage format
 - No validation, comparisons, or orphaned page detection
 - Faster than `dryrun` mode (no API calls)
 
 Use cases:
+
 - Generate Confluence-compatible HTML for manual upload
 - Archive documentation in Confluence format
 - Offline development without Confluence credentials
 - Preview Confluence rendering locally
 
 !!! tip "Dryrun vs Export-Only"
+
     - Use `dryrun: true` when you want to **validate** against Confluence without making changes
     - Use `export_only: true` when you want to **export** to filesystem without connecting to Confluence
 
@@ -272,6 +280,7 @@ debug: true
 ```
 
 When enabled:
+
 - Logs detailed API responses and operations
 - Saves intermediate HTML files to `/tmp/mkdocs-to-confluence-debug/`
 - Shows parent hierarchy resolution details
@@ -287,6 +296,7 @@ debug_diff: true
 ```
 
 When enabled:
+
 - Writes current and new content to `/tmp/confluence-debug/` for comparison
 - Logs character counts and diff commands
 - Shows whether content has changed or not

--- a/docs/user-guide/dry-run.md
+++ b/docs/user-guide/dry-run.md
@@ -1,20 +1,46 @@
-# Dry Run Mode
+# Dry Run and Export Modes
 
-Test your Confluence exports locally before publishing.
+Validate and test your Confluence documentation before publishing.
 
 ## Overview
 
-Dry run mode exports your documentation to a local filesystem instead of uploading to Confluence. This lets you:
+The plugin offers two non-production modes:
 
-- Preview the export structure
-- Inspect converted HTML
-- Verify page hierarchy
-- Test configuration changes
-- Review before production deploy
+### Dry Run Mode (`dryrun: true`)
+
+Validates against Confluence **without making changes**:
+
+- **Connects to Confluence** in read-only mode
+- Validates all pages against existing content
+- Performs content comparisons to detect changes
+- Detects orphaned pages
+- Shows what would be modified ("*WOULD UPDATE*", "*WOULD CREATE*")
+- **Does NOT** create, update, or delete anything
+- Requires valid Confluence credentials
+
+**Use for:** CI/CD validation, preview changes, check orphaned pages
+
+### Export-Only Mode (`export_only: true`)
+
+Exports to filesystem **without connecting to Confluence**:
+
+- **No Confluence connection** required
+- Exports pages to local filesystem in Confluence format
+- No validation or comparisons
+- Faster than dryrun (no API calls)
+- Works offline
+
+**Use for:** Generate HTML for manual upload, offline development, archive documentation
+
+!!! info "Changed in 0.7.0"
+    Previously, `dryrun` exported to filesystem. Now it connects to Confluence for validation.
+    Use `export_only: true` for the old behavior.
 
 ## Configuration
 
-Enable dry run mode in `mkdocs.yml`:
+### Dry Run Mode (Validation)
+
+Enable read-only validation against Confluence:
 
 ```yaml
 plugins:
@@ -22,11 +48,67 @@ plugins:
       host_url: https://company.atlassian.net/wiki/rest/api/content
       space: DOCS
       parent_page_name: Documentation
-      dryrun: true
+      username: !ENV JIRA_USERNAME
+      api_token: !ENV CONFLUENCE_API_TOKEN
+      dryrun: true  # Connects to Confluence in read-only mode
+```
+
+### Export-Only Mode (Filesystem)
+
+Enable filesystem export without Confluence connection:
+
+```yaml
+plugins:
+  - mkdocs-to-confluence:
+      host_url: https://company.atlassian.net/wiki/rest/api/content  # Not used in export_only
+      space: DOCS
+      parent_page_name: Documentation
+      export_only: true  # No Confluence connection
       export_dir: confluence-export
 ```
 
-## Export Structure
+## Dry Run Mode Output
+
+When running with `dryrun: true`, the plugin connects to Confluence and shows what would be done:
+
+```bash
+mkdocs build
+```
+
+Output:
+
+```
+INFO - Mkdocs With Confluence v0.7.0
+INFO - Mkdocs With Confluence - DRYRUN MODE turned ON (read-only, no modifications)
+INFO - Number of files in directory tree: 15
+
+# Existing pages with no changes
+INFO - Mkdocs With Confluence: Home - *NO CHANGE*
+
+# Existing pages that would be updated
+INFO - Mkdocs With Confluence: Getting Started - *WOULD UPDATE* (dryrun)
+
+# New pages that would be created
+INFO - Mkdocs With Confluence: New Feature - *WOULD CREATE* (dryrun)
+
+# Orphaned pages detected
+WARNING - Mkdocs With Confluence: Found 2 orphaned page(s) in Confluence:
+WARNING -   - Old Documentation
+WARNING -   - Deprecated Guide
+INFO - Run with 'cleanup_orphaned_pages: true' to delete them (dryrun mode)
+```
+
+Key behaviors:
+- Fetches existing pages from Confluence
+- Compares content to detect changes
+- Shows "*WOULD UPDATE*" for modified pages
+- Shows "*WOULD CREATE*" for new pages
+- Detects orphaned pages
+- **Does not modify anything** on Confluence
+
+## Export Structure (Export-Only Mode)
+
+When using `export_only: true`, pages are saved to filesystem:
 
 ### Directory Layout
 
@@ -96,7 +178,9 @@ Each `metadata.json` contains:
 </ac:structured-macro>
 ```
 
-## Build and Export
+## Build and Export (Export-Only)
+
+With `export_only: true`:
 
 ```bash
 mkdocs build
@@ -105,10 +189,15 @@ mkdocs build
 Output:
 
 ```
+INFO - Mkdocs With Confluence v0.7.0
+INFO - Mkdocs With Confluence - EXPORT ONLY MODE turned ON (no Confluence connection)
 INFO - Mkdocs With Confluence: Exporting to confluence-export
+INFO - Number of files in directory tree: 15
+
 INFO - Mkdocs With Confluence: Home - *QUEUED FOR EXPORT*
 INFO - Mkdocs With Confluence: Getting Started - *QUEUED FOR EXPORT*
 INFO - Mkdocs With Confluence: Installation - *QUEUED FOR EXPORT*
+
 INFO - Mkdocs With Confluence: Exporting all pages to filesystem...
 INFO - Mkdocs With Confluence: Export complete! Files saved to /path/to/confluence-export
 ```
@@ -223,38 +312,63 @@ rm -rf confluence-export/
 
 ## Common Use Cases
 
-### Preview Before Production
+### Validate Before Publishing (Dryrun)
+
+Use dryrun to validate against Confluence without making changes:
 
 ```bash
-# Test export locally
-DRYRUN=true mkdocs build
+# Validate in dryrun mode
+mkdocs build  # with dryrun: true in config
 
-# Review
-ls -R confluence-export/
+# Review what would be changed
+# Look for "*WOULD UPDATE*" and "*WOULD CREATE*" messages
 
 # Deploy to production
-DRYRUN=false PUBLISH_TO_CONFLUENCE=1 mkdocs build
+# Change dryrun: false, then mkdocs build
 ```
 
-### CI/CD Testing
+### CI/CD Validation Workflow
 
 ```yaml
-# .github/workflows/test-docs.yml
-- name: Test Documentation Export
+# .github/workflows/docs.yml
+- name: Validate documentation (dryrun)
+  env:
+    JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+    CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
+    CONFLUENCE_DRYRUN: "true"
   run: |
-    # Export to filesystem
-    mkdocs build
+    mkdocs build --strict  # Validates against Confluence
+    # Build fails if validation finds issues
 
-    # Verify export
-    test -d confluence-export
-    test -f confluence-export/metadata.json
-
-    # Check page count
-    PAGES=$(cat confluence-export/metadata.json | jq '.total_pages')
-    echo "Exported $PAGES pages"
+- name: Publish to Confluence
+  env:
+    JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+    CONFLUENCE_API_TOKEN: ${{ secrets.CONFLUENCE_API_TOKEN }}
+    CONFLUENCE_DRYRUN: "false"
+  run: |
+    mkdocs build  # Actually publishes
 ```
 
-### Development Workflow
+### Offline Development (Export-Only)
+
+Use export_only for development without Confluence access:
+
+```bash
+# Export to filesystem (no Confluence needed)
+mkdocs build  # with export_only: true in config
+
+# Review HTML files
+ls -R confluence-export/
+cat "confluence-export/Getting Started/page.html"
+
+# Check page count
+PAGES=$(cat confluence-export/metadata.json | jq '.total_pages')
+echo "Exported $PAGES pages"
+```
+
+### Environment-Based Configuration
+
+Control modes via environment variables:
 
 ```yaml
 # mkdocs.yml
@@ -262,35 +376,70 @@ plugins:
   - mkdocs-to-confluence:
       host_url: https://company.atlassian.net/wiki/rest/api/content
       space: DOCS
-      # Use environment variable to control mode
-      dryrun: !ENV [DRYRUN, false]
+      username: !ENV JIRA_USERNAME
+      api_token: !ENV CONFLUENCE_API_TOKEN
+      dryrun: !ENV [CONFLUENCE_DRYRUN, false]
+      export_only: !ENV [CONFLUENCE_EXPORT_ONLY, false]
       export_dir: confluence-export
 ```
 
 ```bash
-# Development: dry run
-DRYRUN=true mkdocs build
+# Validate against Confluence (dryrun)
+CONFLUENCE_DRYRUN=true mkdocs build
 
-# Production: real upload
-DRYRUN=false mkdocs build
+# Export to filesystem (export_only)
+CONFLUENCE_EXPORT_ONLY=true mkdocs build
+
+# Publish to Confluence (normal)
+mkdocs build
 ```
 
 ## Troubleshooting
 
-### Export Directory Not Created
+### Dryrun Mode Issues
+
+#### Connection Errors in Dryrun
+
+If dryrun fails to connect to Confluence:
+
+```
+ERROR - Cannot connect to Confluence: Connection refused
+```
+
+Check:
+- Credentials are set (`JIRA_USERNAME`, `CONFLUENCE_API_TOKEN`)
+- `host_url` is correct
+- Network access to Confluence
+
+**Solution:** Use `export_only: true` if you don't need validation
+
+#### Authentication Failures
+
+```
+ERROR - 403 Client Error: Forbidden
+```
+
+Check:
+- API token has correct permissions
+- Username matches the token owner
+- Space is accessible by the user
+
+### Export-Only Mode Issues
+
+#### Export Directory Not Created
 
 Check plugin configuration:
 
 ```yaml
 plugins:
   - mkdocs-to-confluence:  # Correct
-      dryrun: true
+      export_only: true
 
   # NOT:
   - mkdocs-to-confluence  # Wrong - no configuration
 ```
 
-### Missing Pages
+#### Missing Pages
 
 Ensure pages are in navigation:
 
@@ -300,16 +449,18 @@ nav:
   - Guide: guide.md  # Must be in nav to export
 ```
 
-### Incorrect Hierarchy
+### General Issues
 
-Check `parent` field in metadata files. Should match your navigation structure.
+#### Incorrect Hierarchy
 
-### Malformed HTML
+In export_only mode, check `parent` field in metadata files. Should match your navigation structure.
+
+#### Malformed HTML
 
 Enable debug mode to see conversion details:
 
 ```yaml
-dryrun: true
+export_only: true  # or dryrun: true
 debug: true
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,8 @@ plugins:
       username: !ENV JIRA_USERNAME
       api_token: !ENV CONFLUENCE_API_TOKEN
       dryrun: !ENV [CONFLUENCE_DRYRUN, false]
-      debug: true
+      debug: !ENV [CONFLUENCE_DEBUG, false]
+      verbose: !ENV [CONFLUENCE_VERBOSE, false]
       debug_diff: false
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
       dryrun: !ENV [CONFLUENCE_DRYRUN, false]
       debug: !ENV [CONFLUENCE_DEBUG, false]
       verbose: !ENV [CONFLUENCE_VERBOSE, false]
-      debug_diff: false
+      debug_diff: !ENV [CONFLUENCE_DIFF, false]
 
 nav:
   - Home: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 strict_equality = true
 pretty = true
-exclude = ["docs/"]
+exclude = ["docs/", "src/mkdocs_to_confluence/_vendor/"]
 ignore_missing_imports = true
 
 # ---- MkDocs ----

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ from setuptools import find_packages, setup
 setup(
     name="mkdocs-to-confluence",
     version="0.6.0",
-    description="MkDocs plugin for converting and uploading Markdown pages to Confluence with automatic synchronization (via REST API)",
+    description=(
+        "MkDocs plugin for converting and uploading Markdown pages to Confluence "
+        "with automatic synchronization (via REST API)"
+    ),
     keywords="mkdocs markdown confluence documentation sync synchronization",
     url="https://github.com/jmanteau/mkdocs-to-confluence/",
     author="Julien Manteau",

--- a/src/mkdocs_to_confluence/_vendor/md2cf/__main__.py
+++ b/src/mkdocs_to_confluence/_vendor/md2cf/__main__.py
@@ -344,10 +344,11 @@ def main():
 
     for page in pages_to_upload:
         for attachment in page.attachments:
-            if page.file_path is not None:
-                attachment_path = page.file_path.parent.joinpath(attachment)
-            else:
-                attachment_path = attachment
+            attachment_path = (
+                page.file_path.parent.joinpath(attachment)
+                if page.file_path is not None
+                else attachment
+            )
 
             if not attachment_path.is_file():
                 error_console.log(
@@ -376,7 +377,7 @@ def main():
             args.postface_file
         ).body
 
-    map_document_path_to_confluence_page = dict()
+    map_document_path_to_confluence_page = {}
     if args.enable_relative_links:
         map_document_path_to_confluence_page = build_document_path_to_page_map(
             pages_to_upload
@@ -561,7 +562,7 @@ def validate_relative_links(pages_to_upload, path_to_page):
 
 
 def build_document_path_to_page_map(pages_to_upload):
-    path_to_page = dict()
+    path_to_page = {}
     for page in pages_to_upload:
         try:
             # Will be filled in later with the page returned by upsert
@@ -670,7 +671,7 @@ def update_pages_with_relative_links(
 
 
 def collect_pages_to_upload(args):
-    pages_to_upload: List[Page] = list()
+    pages_to_upload: List[Page] = []
     if not args.file_list:  # Uploading from standard input
         pages_to_upload.append(
             md2cf.document.get_page_data_from_lines(

--- a/src/mkdocs_to_confluence/_vendor/md2cf/api.py
+++ b/src/mkdocs_to_confluence/_vendor/md2cf/api.py
@@ -20,7 +20,7 @@ class Bunch(dict):
             kwargs = {}
         for key, value in kwargs.items():
             kwargs[key] = bunchify(value)
-        super(Bunch, self).__init__(kwargs)
+        super().__init__(kwargs)
         self.__dict__ = self
 
 
@@ -28,12 +28,11 @@ class MinimalConfluence:
     def __init__(
         self, host, username=None, password=None, token=None, verify=True, max_retries=4
     ):
-        if token is None:
-            if username is None and password is None:
-                raise ValueError(
-                    "Either a personal access token, "
-                    "or username and password are required"
-                )
+        if token is None and username is None and password is None:
+            raise ValueError(
+                "Either a personal access token, "
+                "or username and password are required"
+            )
 
         if not host.endswith("/"):
             self.host = host + "/"
@@ -86,7 +85,7 @@ class MinimalConfluence:
         content_type="page",
         additional_expansions=None,
     ):
-        """Create a new page in a space
+        """Create a new page in a space.
 
         Args:
             title (str): the title for the page
@@ -136,7 +135,7 @@ class MinimalConfluence:
         update_message=None,
         labels=None,
     ):
-        """Create a new page in a space
+        """Create a new page in a space.
 
         Args:
             space (str): the Confluence space for the page

--- a/src/mkdocs_to_confluence/_vendor/md2cf/confluence_renderer.py
+++ b/src/mkdocs_to_confluence/_vendor/md2cf/confluence_renderer.py
@@ -98,14 +98,14 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
         super().__init__(**kwargs)
         self.strip_header = strip_header
         self.remove_text_newlines = remove_text_newlines
-        self.attachments = list()
+        self.attachments = []
         self.title = None
         self.enable_relative_links = enable_relative_links
-        self.relative_links: List[RelativeLink] = list()
+        self.relative_links: List[RelativeLink] = []
 
     def reinit(self):
-        self.attachments = list()
-        self.relative_links = list()
+        self.attachments = []
+        self.relative_links = []
         self.title = None
 
     def header(self, text, level, raw=None):
@@ -115,7 +115,7 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
             if self.strip_header:
                 return ""
 
-        return super(ConfluenceRenderer, self).header(text, level, raw=raw)
+        return super().header(text, level, raw=raw)
 
     def structured_macro(self, name, text=""):
         return ConfluenceTag("structured-macro", attrib={"name": name}, text=text)
@@ -156,7 +156,7 @@ class ConfluenceRenderer(mistune.HTMLRenderer):
                 )
             )
             url = replacement_link
-        return super(ConfluenceRenderer, self).link(text, url, title)
+        return super().link(text, url, title)
 
     def text(self, text):
         if self.remove_text_newlines:

--- a/src/mkdocs_to_confluence/_vendor/md2cf/document.py
+++ b/src/mkdocs_to_confluence/_vendor/md2cf/document.py
@@ -1,3 +1,4 @@
+import contextlib
 import hashlib
 import os
 from pathlib import Path
@@ -33,10 +34,10 @@ class Page:
         self.file_path = file_path
         self.attachments = attachments
         if self.attachments is None:
-            self.attachments: List[Path] = list()
+            self.attachments: List[Path] = []
         self.relative_links = relative_links
         if self.relative_links is None:
-            self.relative_links: List[RelativeLink] = list()
+            self.relative_links: List[RelativeLink] = []
         self.page_id = page_id
         self.parent_id = parent_id
         self.parent_title = parent_title
@@ -44,7 +45,7 @@ class Page:
         self.labels = labels
 
     def get_content_hash(self):
-        return hashlib.sha1(self.body.encode()).hexdigest()
+        return hashlib.sha1(self.body.encode()).hexdigest()  # noqa: S324  # nosec B324
 
     def __repr__(self):
         return "Page({})".format(
@@ -107,9 +108,9 @@ def get_pages_from_directory(
       placeholders
     :return: A list of paths to the markdown files to upload.
     """
-    processed_pages = list()
+    processed_pages = []
     base_path = file_path.resolve()
-    folder_data = dict()
+    folder_data = {}
     git_repo = GitRepository(file_path, use_gitignore=use_gitignore)
 
     for current_path, directories, file_names in os.walk(file_path):
@@ -304,10 +305,8 @@ def get_document_frontmatter(markdown_lines: List[str]) -> Dict[str, Any]:
                 frontmatter_yaml += line
     frontmatter = None
     if frontmatter_yaml and frontmatter_end_line:
-        try:
+        with contextlib.suppress(ParserError):
             frontmatter = yaml.safe_load(frontmatter_yaml)
-        except ParserError:
-            pass
     if isinstance(frontmatter, dict):
         frontmatter["frontmatter_end_line"] = frontmatter_end_line
     else:

--- a/src/mkdocs_to_confluence/_vendor/md2cf/ignored_files.py
+++ b/src/mkdocs_to_confluence/_vendor/md2cf/ignored_files.py
@@ -1,5 +1,4 @@
-"""Allow checking files for ignored status in gitignore files in the repo.
-"""
+"""Allow checking files for ignored status in gitignore files in the repo."""
 from pathlib import Path
 from typing import List
 
@@ -8,8 +7,9 @@ from md2cf.console_output import error_console
 
 
 class GitRepository:
-    """Represents a Git repository by finding the .git folder at the root
-    of the tree. Note that there are cases where .git folders may exist
+    """Represents a Git repository by finding the .git folder at the root of the tree.
+
+    Note that there are cases where .git folders may exist
     in other parts of the tree. For example in terraform repositories
     the .terraform folder may contain copies of the tree including the .git
     folder. This can be handled by initializing the GitRepository from a
@@ -23,7 +23,8 @@ class GitRepository:
 
     @staticmethod
     def _find_root_dir(start_path: Path):
-        """Traverse the parents of the start_path until we find a .git directory
+        """Traverse the parents of the start_path until we find a .git directory.
+
         :param start_path: A file or directory path to start searching from
         :return: The root directory of the git repo.
         """
@@ -43,15 +44,16 @@ class GitRepository:
         return None
 
     def collect_gitignores(self, filepath: Path) -> List[Path]:
-        """Collect all .gitignore files from start location to the root of the
-        repository. Filepath is assumed to be a subdirectory of the git root.
+        """Collect all .gitignore files from start location to the root of the repository.
+
+        Filepath is assumed to be a subdirectory of the git root.
         If not, an error is printed and an empty list is returned.
 
         :param filepath: The path to start searching for .gitignore files
         :return: List of paths to .gitignore files relevant for start_path
         """
         fs_root = Path("/")
-        ret = list()
+        ret = []
 
         p = filepath.absolute()
         if p.is_file():
@@ -66,11 +68,12 @@ class GitRepository:
 
         # if not .git directory found, we're not in a git repo and gitignore files
         # cannot be trusted.
-        return list()
+        return []
 
     def is_ignored(self, filepath: Path) -> bool:
-        """Check if filepath is ignored in the git repository by fetching all gitignores
-        in the tree down to the git root and checking all of them.
+        """Check if filepath is ignored in the git repository.
+
+        Fetches all gitignores in the tree down to the git root and checks all of them.
 
         :param filepath: Path to the file to check if it is ignored.
         :return: True if the file is ignored in any .gitignore file
@@ -81,4 +84,4 @@ class GitRepository:
             return False
         gitignores = self.collect_gitignores(filepath)
         matchers = [gitignorefile.parse(str(g)) for g in gitignores]
-        return any([m(str(filepath)) for m in matchers])
+        return any(m(str(filepath)) for m in matchers)

--- a/src/mkdocs_to_confluence/_vendor/md2cf/tui.py
+++ b/src/mkdocs_to_confluence/_vendor/md2cf/tui.py
@@ -13,8 +13,8 @@ class Md2cfTUI:
         tree = rich.tree.Tree("Pages to upload", hide_root=True)
         progress_table = rich.table.Table.grid()
         progress_table.row_styles = ["dim", ""]
-        title_to_tree: Dict[str, rich.tree.Tree] = dict()
-        self.title_to_progress: Dict[str, rich.progress.Progress] = dict()
+        title_to_tree: Dict[str, rich.tree.Tree] = {}
+        self.title_to_progress: Dict[str, rich.progress.Progress] = {}
         for page in pages_to_upload:
             if page.file_path is None and len(pages_to_upload) > 1:
                 pretty_title = f":open_file_folder: {page.title}"

--- a/src/mkdocs_to_confluence/_vendor/md2cf/upsert.py
+++ b/src/mkdocs_to_confluence/_vendor/md2cf/upsert.py
@@ -23,7 +23,7 @@ class UpsertResult(NamedTuple):
 
 # Adapted from https://stackoverflow.com/a/3431838
 def get_file_sha1(file_path: Path):
-    hash_sha1 = hashlib.sha1()
+    hash_sha1 = hashlib.sha1()  # noqa: S324  # nosec B324
     with open(file_path, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_sha1.update(chunk)
@@ -70,9 +70,8 @@ def upsert_page(
 
     # It's not mandatory to have a parent ID -- if there isn't one, the page will be a
     # top-level page in the Confluence space
-    if page.parent_id is None:
-        if page.parent_title is not None:
-            page.parent_id = get_parent_id_from_title(confluence, page)
+    if page.parent_id is None and page.parent_title is not None:
+        page.parent_id = get_parent_id_from_title(confluence, page)
 
     page_message = message
     if only_changed:
@@ -162,10 +161,11 @@ def page_needs_updating(page, existing_page, replace_all_labels):
 def upsert_attachment(
     confluence, attachment, existing_page, message, only_changed, page
 ):
-    if page.file_path is not None:
-        attachment_path = page.file_path.parent.joinpath(attachment)
-    else:
-        attachment_path = attachment
+    attachment_path = (
+        page.file_path.parent.joinpath(attachment)
+        if page.file_path is not None
+        else attachment
+    )
 
     attachment_message = message
     if only_changed:

--- a/src/mkdocs_to_confluence/plugin.py
+++ b/src/mkdocs_to_confluence/plugin.py
@@ -271,7 +271,10 @@ class MkdocsWithConfluence(BasePlugin):
 
         # Handle export_only and dryrun modes
         if self.config["export_only"] and self.config["dryrun"]:
-            logger.warning("Both export_only and dryrun are enabled. Using export_only mode (no Confluence connection).")
+            logger.warning(
+                "Both export_only and dryrun are enabled. "
+                "Using export_only mode (no Confluence connection)."
+            )
             self.export_only = True
             self.dryrun = False
             export_dir = Path(self.config["export_dir"])
@@ -654,7 +657,10 @@ class MkdocsWithConfluence(BasePlugin):
                             logger.info(f"Mkdocs With Confluence: {item} *WOULD CREATE* (dryrun)")
                     # In dryrun, we can't create pages, so we can't get their IDs
                     # This will cause issues for child pages, but that's expected in validation mode
-                    logger.warning(f"Cannot create parent '{parent_title}' in dryrun mode - child pages may fail validation")
+                    logger.warning(
+                        f"Cannot create parent '{parent_title}' in dryrun mode - "
+                        "child pages may fail validation"
+                    )
                     return None
                 else:
                     self.add_page(parent_title, current_parent_id, body)
@@ -881,7 +887,7 @@ class MkdocsWithConfluence(BasePlugin):
                 username = self.config["username"] or ""
                 if username == "":
                     logger.warning("Username is not configured. Check plugin configuration or environment variables.")
-                if token == "":
+                if token == "":  # nosec B105
                     logger.warning("API token is not configured. Check plugin configuration or environment variables.")
                 self.session.auth = (username, token)
         else:
@@ -890,7 +896,7 @@ class MkdocsWithConfluence(BasePlugin):
             password = self.config["password"] or ""
             if username == "":
                 logger.warning("Username is not configured. Check plugin configuration or environment variables.")
-            if password == "":
+            if password == "":  # nosec B105
                 logger.warning("Password is not configured. Check plugin configuration or environment variables.")
             self.session.auth = (username, password)
 
@@ -988,7 +994,7 @@ class MkdocsWithConfluence(BasePlugin):
                 if self.dryrun:
                     logger.info(f"  * Attachment: {p.name} - *WOULD UPLOAD* (dryrun)")
                 else:
-                    self.add_or_update_attachment(page.title, p)
+                    self.add_or_update_attachment(page.title, str(p))
         return output
 
     def on_page_content(self, html: str, page: Any, config: Any, files: Any) -> str:
@@ -1089,7 +1095,10 @@ class MkdocsWithConfluence(BasePlugin):
                 logger.info(f"Mkdocs With Confluence: Deleted {deleted_count} orphaned page(s)")
         else:
             if self.dryrun:
-                logger.info("Mkdocs With Confluence: Run with 'cleanup_orphaned_pages: true' to delete them (dryrun mode)")
+                logger.info(
+                    "Mkdocs With Confluence: Run with 'cleanup_orphaned_pages: true' "
+                    "to delete them (dryrun mode)"
+                )
             else:
                 logger.info("Mkdocs With Confluence: Run with 'cleanup_orphaned_pages: true' to delete them")
 
@@ -1283,6 +1292,7 @@ class MkdocsWithConfluence(BasePlugin):
             response_json = r.json()
         if response_json["size"]:
             return response_json["results"][0]
+        return None
 
     def update_attachment(self, page_id, filepath, existing_attachment, message):
         """Update existing attachment on Confluence page.

--- a/tests/fixtures/configs.py
+++ b/tests/fixtures/configs.py
@@ -11,7 +11,9 @@ MINIMAL_CONFIG = {
     "enabled_if_env": None,
     "verbose": False,
     "debug": False,
+    "debug_diff": False,
     "dryrun": False,
+    "export_only": False,
     "export_dir": "confluence-export",
     "strip_h1": False,
 }
@@ -28,7 +30,9 @@ CONFIG_WITH_API_TOKEN = {
     "enabled_if_env": None,
     "verbose": False,
     "debug": False,
+    "debug_diff": False,
     "dryrun": False,
+    "export_only": False,
     "export_dir": "confluence-export",
 }
 
@@ -44,7 +48,9 @@ CONFIG_WITH_BEARER_AUTH = {
     "enabled_if_env": None,
     "verbose": False,
     "debug": False,
+    "debug_diff": False,
     "dryrun": False,
+    "export_only": False,
     "export_dir": "confluence-export",
 }
 
@@ -59,7 +65,9 @@ CONFIG_DEBUG_MODE = {
     "enabled_if_env": None,
     "verbose": False,
     "debug": True,
+    "debug_diff": False,
     "dryrun": False,
+    "export_only": False,
     "export_dir": "confluence-export",
 }
 
@@ -74,7 +82,9 @@ CONFIG_DRYRUN_MODE = {
     "enabled_if_env": None,
     "verbose": False,
     "debug": False,
+    "debug_diff": False,
     "dryrun": True,
+    "export_only": False,
     "export_dir": "confluence-export",
 }
 
@@ -89,7 +99,9 @@ CONFIG_WITH_ENV_CHECK = {
     "enabled_if_env": "CONFLUENCE_UPLOAD",
     "verbose": False,
     "debug": False,
+    "debug_diff": False,
     "dryrun": False,
+    "export_only": False,
     "export_dir": "confluence-export",
 }
 
@@ -104,6 +116,8 @@ INCOMPLETE_CONFIG = {
     "enabled_if_env": None,
     "verbose": False,
     "debug": False,
+    "debug_diff": False,
     "dryrun": False,
+    "export_only": False,
     "export_dir": "confluence-export",
 }

--- a/tests/test_config_init.py
+++ b/tests/test_config_init.py
@@ -241,7 +241,7 @@ def test_incomplete_config_handling():
 
 def test_bearer_auth_class():
     """Test BearerAuth class correctly formats Authorization header."""
-    token = "test_oauth_token_12345"
+    token = "test_oauth_token_12345"  # noqa: S105
     auth = BearerAuth(token)
 
     # Create a mock request object
@@ -270,7 +270,7 @@ def test_plugin_auth_with_bearer_token():
 
     # Verify BearerAuth was used
     assert isinstance(plugin.session.auth, BearerAuth)
-    assert plugin.session.auth.token == "oauth_bearer_token_example_1234567890"
+    assert plugin.session.auth.token == "oauth_bearer_token_example_1234567890"  # noqa: S105
 
 
 def test_plugin_auth_type_defaults_to_basic():
@@ -287,5 +287,5 @@ def test_plugin_config_with_bearer_auth():
     plugin.config = CONFIG_WITH_BEARER_AUTH.copy()
 
     assert plugin.config["auth_type"] == "bearer"
-    assert plugin.config["api_token"] == "oauth_bearer_token_example_1234567890"
+    assert plugin.config["api_token"] == "oauth_bearer_token_example_1234567890"  # noqa: S105
     assert plugin.config["username"] == "test_user"

--- a/tests/test_orphaned_pages.py
+++ b/tests/test_orphaned_pages.py
@@ -290,16 +290,16 @@ def test_ensure_parent_hierarchy_tracks_parent_pages():
 
 
 @responses.activate
-def test_on_post_build_skips_when_dryrun():
-    """Test on_post_build skips orphaned detection in dryrun mode."""
+def test_on_post_build_skips_when_export_only():
+    """Test on_post_build skips orphaned detection in export_only mode."""
     plugin = MkdocsWithConfluence()
     config = MINIMAL_CONFIG.copy()
-    config["dryrun"] = True
+    config["export_only"] = True
     plugin.config = config
-    plugin.dryrun = True
+    plugin.export_only = True
     plugin.enabled = True
 
-    # Should not make any API calls
+    # Should not make any API calls in export_only mode
     plugin.on_post_build({})
 
     assert len(responses.calls) == 0

--- a/tests/test_refactored_methods.py
+++ b/tests/test_refactored_methods.py
@@ -99,7 +99,7 @@ def test_extract_attachments_file_protocol():
     markdown = '<img src="file:///tmp/image1.png" s'
     attachments = plugin._extract_attachments(markdown)
 
-    assert "/tmp/image1.png" in attachments
+    assert "/tmp/image1.png" in attachments  # noqa: S108
 
 
 def test_extract_attachments_markdown_format():
@@ -125,7 +125,7 @@ def test_extract_attachments_mixed_formats():
     '''
     attachments = plugin._extract_attachments(markdown)
 
-    assert "/tmp/temp_image.png" in attachments
+    assert "/tmp/temp_image.png" in attachments  # noqa: S108
     assert "diagrams/architecture.png" in attachments
     assert "docs/diagrams/architecture.png" in attachments
 


### PR DESCRIPTION
## Summary

Reworks the plugin's non-production modes into two distinct operations:

- **`dryrun: true`** now connects to Confluence in **read-only mode** — validates pages, compares content, detects orphans, and reports what *would* change (`*WOULD UPDATE*`, `*WOULD CREATE*`, `*WOULD DELETE*`) without modifying anything.
- **`export_only: true`** (new) exports pages to the local filesystem **without any Confluence connection** — the old `dryrun` behavior, useful for offline development and CI without credentials.

### What changed

**Core plugin (`plugin.py`)**
- New `export_only` config option and mode, with clear precedence when both flags are set
- Dryrun mode now performs real Confluence reads (page fetches, content diffs, orphan detection) but skips all writes (create/update/delete/upload)
- Page status tracking (`page_status` dict) with end-of-build summary in verbose/debug mode
- Environment variable overrides for `CONFLUENCE_DEBUG` and `CONFLUENCE_VERBOSE`
- Removed `on_post_template` hook and `simple_log` flag — progress bar now driven directly by `verbose`/`debug` config
- Attachment upload path passed as `str` instead of `Path` (bug fix)
- New `remove_text_newlines` config option (default `true`) to strip hard-wrapped newlines from paragraphs before publishing to Confluence (fixes #9)
- Explicit `return None` in `get_attachment` (type safety)

**Vendor code (`_vendor/md2cf/`)**
- Modernized Python idioms: `dict()` → `{}`, `list()` → `[]`, `super(Cls, self)` → `super()`
- Collapsed nested `if` conditions, replaced bare `except: pass` with `contextlib.suppress`
- Added `# nosec` / `# noqa` for false-positive security warnings (SHA1 used for content hashing, not cryptography)
- Docstring formatting fixes

**CI & build**
- Added a diff-validation step to the docs workflow (`CONFLUENCE_DIFF=true`)
- `CONFLUENCE_DEBUG` enabled in CI validation steps
- `mkdocs.yml`: `debug`, `verbose`, `debug_diff` now configurable via environment variables
- Makefile: fixed paths from old `mkdocs_with_confluence` to `src/mkdocs_to_confluence`; added `MYPYPATH=src` for mypy
- `pyproject.toml`: excluded vendor directory from mypy

**Tests**
- All config fixtures updated with `debug_diff` and `export_only` fields
- `test_on_post_build_skips_when_dryrun` renamed to `test_on_post_build_skips_when_export_only`
- Added `# noqa: S105` / `# noqa: S108` suppressions for test token strings and `/tmp` paths

**Documentation**
- Rewrote `dry-run.md` as "Dry Run and Export Modes" with separate sections, example output, and migration note
- Updated `configuration.md` reference with new `export_only` and revised `dryrun` descriptions
- Updated getting-started guide to recommend `export_only` for first-time local testing
- Updated `README.md` and `docs/index.md` feature lists

## Breaking changes

- `dryrun: true` no longer exports to filesystem — it now requires Confluence credentials for read-only validation. Use `export_only: true` for the previous filesystem-export behavior.

## Test plan

- [ ] `make quality && make test` passes
- [ ] `export_only: true` exports pages to filesystem without Confluence connection
- [ ] `dryrun: true` connects to Confluence, reports WOULD UPDATE/CREATE/DELETE, but makes no modifications
- [ ] Both flags set: `export_only` takes precedence with a warning
- [ ] `CONFLUENCE_DEBUG=true` / `CONFLUENCE_VERBOSE=true` env vars override config
- [ ] CI workflow runs validation, diff, and publish steps in order
- [ ] Page status summary appears in verbose/debug output at end of build