### PR TITLE
Fixed rendering of tables in confluence

### DIFF
--- a/src/mkdocs_to_confluence/plugin.py
+++ b/src/mkdocs_to_confluence/plugin.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import mistune
 import requests
+from mistune.plugins.table import table as mistune_table
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
 from requests.auth import AuthBase
@@ -106,7 +107,7 @@ class MkdocsWithConfluence(BasePlugin):
         """Initialize plugin with default settings."""
         self.enabled = True
         self.confluence_renderer = ConfluenceRenderer()
-        self.confluence_mistune = mistune.Markdown(renderer=self.confluence_renderer)
+        self.confluence_mistune = mistune.Markdown(renderer=self.confluence_renderer, plugins=[mistune_table])
         self.simple_log = False
         self.flen = 1
         self.session = requests.Session()

--- a/tests/fixtures/markdown_samples.py
+++ b/tests/fixtures/markdown_samples.py
@@ -50,6 +50,13 @@ This page contains only text content with no images or attachments.
 - Item 3
 """
 
+# Markdown table sample
+MARKDOWN_WITH_TABLE = """| Name  | Role    |
+| ----- | ------- |
+| Alice | Admin   |
+| Bob   | Viewer  |
+"""
+
 # Expected attachment lists
 EXPECTED_ATTACHMENTS_FILE = [
     "/tmp/test_image.png",  # noqa: S108

--- a/tests/test_refactored_methods.py
+++ b/tests/test_refactored_methods.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from mkdocs_to_confluence.plugin import MkdocsWithConfluence
 from tests.fixtures.configs import MINIMAL_CONFIG
+from tests.fixtures.markdown_samples import MARKDOWN_WITH_TABLE
 
 # ============================================================================
 # Tests for _resolve_page_parents()
@@ -201,3 +202,25 @@ def test_convert_to_confluence_format_handles_special_chars_in_page_name():
     assert isinstance(confluence_body, str)
     assert len(confluence_body) > 0
     assert '<h1>' in confluence_body or 'Test' in confluence_body
+
+
+def test_convert_to_confluence_format_handles_tables():
+    """Test _convert_to_confluence_format() converts markdown tables to HTML tables."""
+    plugin = MkdocsWithConfluence()
+    plugin.config = MINIMAL_CONFIG.copy()
+
+    confluence_body = plugin._convert_to_confluence_format(MARKDOWN_WITH_TABLE, "TablePage")
+
+    assert isinstance(confluence_body, str)
+    assert len(confluence_body) > 0
+    assert "<table>" in confluence_body
+    assert "<thead>" in confluence_body
+    assert "<tbody>" in confluence_body
+    assert "<th>Name</th>" in confluence_body
+    assert "<th>Role</th>" in confluence_body
+    assert "<td>Alice</td>" in confluence_body
+    assert "<td>Admin</td>" in confluence_body
+    assert "<td>Bob</td>" in confluence_body
+    assert "<td>Viewer</td>" in confluence_body
+    assert confluence_body.count("<tr>") == 3
+    


### PR DESCRIPTION
The plugin wasn't converting Markdown tables correctly. This PR provides a fix for this issue.
Linting and type checking flagged significantly more errors that had nothing to do with my changes. I primarily ran the quality checks only on my changes.
If anything else needs to be changed, please let me know. 